### PR TITLE
依存関係を表すキー名が誤っていたため修正

### DIFF
--- a/multiserverreward/src/main/resources/plugin.yml
+++ b/multiserverreward/src/main/resources/plugin.yml
@@ -3,5 +3,4 @@ name: MultiServerReward
 version: "1.0.1"
 api: 1.16.5
 api-version: 1.16
-depends:
-  - LeonGunWar
+depend: ["LeonGunWar"]


### PR DESCRIPTION
plugin.ymlにおいて依存関係を表すキー名が誤っていた
誤：`depends`
正：`depend`
誤っている状態では起動時ログに警告が出力されていたが、修正後出ないことを確認した