### PR TITLE
ログ＆統計機能追加

### DIFF
--- a/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/IReward.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/IReward.java
@@ -2,6 +2,8 @@ package com.github.aburaagetarou.reward.config.type;
 
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nullable;
+
 /**
  * 報酬を表すインターフェース
  * @author AburaAgeTarou

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardBalance.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardBalance.java
@@ -1,7 +1,9 @@
 package com.github.aburaagetarou.reward.config.type;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
+import com.github.aburaagetarou.statistics.IStatisticsTarget;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -12,7 +14,7 @@ import com.github.aburaagetarou.config.MSRConfig;
  * ＄報酬を表すクラス
  * @author AburaAgeTarou
  */
-public class RewardBalance extends SumRewardBase {
+public class RewardBalance extends SumRewardBase implements IStatisticsTarget {
     
     // 報酬コマンド
     private final int balance;
@@ -23,7 +25,7 @@ public class RewardBalance extends SumRewardBase {
      */
     public RewardBalance(Double balance) {
         BigDecimal bd = new BigDecimal(balance);
-        bd = bd.setScale(0, BigDecimal.ROUND_HALF_UP);
+        bd = bd.setScale(0, RoundingMode.HALF_UP);
         this.balance = bd.intValue();
     }
 
@@ -42,7 +44,7 @@ public class RewardBalance extends SumRewardBase {
      */
     @Override
     public double getAmount() {
-        return (double)balance;
+        return balance;
     }
 
     /**
@@ -68,7 +70,33 @@ public class RewardBalance extends SumRewardBase {
             command = command.replace("<amount>", String.valueOf(balance));
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
         });
-        return;
+    }
+
+    /**
+     * 報酬名を得る
+     * @return 報酬名
+     */
+    @Override
+    public String getStatCategory() {
+        return "Balance";
+    }
+
+    /**
+     * 報酬名を得る
+     * @return 報酬名
+     */
+    @Override
+    public String getStatData() {
+        return "$";
+    }
+
+    /**
+     * 報酬数量を得る
+     * @return 報酬名
+     */
+    @Override
+    public double getStatAmount() {
+        return balance;
     }
 
     /**

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardCommand.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardCommand.java
@@ -1,5 +1,6 @@
 package com.github.aburaagetarou.reward.config.type;
 
+import com.github.aburaagetarou.statistics.IStatisticsTarget;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -9,7 +10,7 @@ import com.github.aburaagetarou.MultiServerReward;
  * コマンド実行による報酬を表すクラス
  * @author AburaAgeTarou
  */
-public class RewardCommand extends SingleRewardBase {
+public class RewardCommand extends SingleRewardBase implements IStatisticsTarget {
     
     // 報酬コマンド
     private final String command;
@@ -60,8 +61,33 @@ public class RewardCommand extends SingleRewardBase {
         Bukkit.getScheduler().runTask(MultiServerReward.getInstance(), () -> {
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.replace("<player>", player.getName()));
         });
+    }
 
-        return;
+    /**
+     * 報酬名を得る
+     * @return 報酬名
+     */
+    @Override
+    public String getStatCategory() {
+        return "Command";
+    }
+
+    /**
+     * 報酬名を得る
+     * @return 報酬名
+     */
+    @Override
+    public String getStatData() {
+        return command;
+    }
+
+    /**
+     * 報酬数量を得る
+     * @return 報酬名
+     */
+    @Override
+    public double getStatAmount() {
+        return 1.0d;
     }
 
     /**

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardMessage.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/reward/config/type/RewardMessage.java
@@ -73,7 +73,6 @@ public class RewardMessage extends SingleRewardBase {
      */
     @Override
     public String toString() {
-        String result = "&7[全体メッセージ] &r" + message;
-        return result;
+        return "&7[全体メッセージ] &r" + message;
     }
 }

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/reward/manage/FileRewardManager.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/reward/manage/FileRewardManager.java
@@ -19,6 +19,8 @@ import com.github.aburaagetarou.reward.config.RewardType;
 import com.github.aburaagetarou.reward.config.type.IReward;
 import com.github.aburaagetarou.reward.config.type.SingleRewardBase;
 import com.github.aburaagetarou.reward.config.type.SumRewardBase;
+import com.github.aburaagetarou.statistics.IStatisticsTarget;
+import com.github.aburaagetarou.statistics.StatisticsUtil;
 
 /**
  * ファイルによる報酬管理クラス
@@ -144,13 +146,18 @@ public class FileRewardManager extends RewardManager {
             // 合計報酬の場合
             if(reward instanceof SumRewardBase) {
                 if(!sumRewards.containsKey(parentKey)) {
-                    BigDecimal sum = new BigDecimal(0.0d);
+                    BigDecimal sum = new BigDecimal("0.0");
                     for(double amount : yml.getDoubleList(parentKey)) {
                         sum = sum.add(new BigDecimal(amount));
                     }
                     sumRewards.put(parentKey, sum);
                 }
                 sumRewards.put(parentKey, sumRewards.get(parentKey).add(new BigDecimal(((SumRewardBase)reward).getAmount())));
+            }
+
+            // 統計対象の場合
+            if(reward instanceof IStatisticsTarget) {
+                StatisticsUtil.writeData(MultiServerReward.getStatisticsWriter(), (IStatisticsTarget)reward, player);
             }
         }
         for(String key : sumRewards.keySet()) {

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/FileStatisticsWriter.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/FileStatisticsWriter.java
@@ -1,0 +1,52 @@
+package com.github.aburaagetarou.statistics;
+
+import com.github.aburaagetarou.MultiServerReward;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+
+/**
+ * ファイルへの統計書き込み
+ * @author AburaAgeTarou
+ */
+public class FileStatisticsWriter implements IStatisticsWriter {
+
+	// ファイルオブジェクト
+	File file;
+
+	/**
+	 * コンストラクタ
+	 * @param file ファイルオブジェクト もしくはファイルパス
+	 */
+	public FileStatisticsWriter(File file) {
+		this.file = file;
+	}
+	public FileStatisticsWriter(String file) {
+		this.file = new File(file);
+	}
+
+	/**
+	 * 報酬統計データを書き込む
+	 * @param content 報酬統計データ
+	 */
+	@Override
+	public boolean write(String content) {
+		if(file == null) return false;
+		try {
+			if(!file.exists()) {
+				if(!file.createNewFile()) return false;
+			}
+			if(file.isDirectory()) {
+				throw new IOException("File is directory: " + file.getPath());
+			}
+			Files.write(file.toPath(), Collections.singletonList(content), StandardOpenOption.APPEND);
+		} catch (IOException e) {
+			MultiServerReward.getInstance().getLogger().warning("Failed to write reward data: " + file.getPath());
+			return false;
+		}
+		return true;
+	}
+}

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/IStatisticsTarget.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/IStatisticsTarget.java
@@ -1,0 +1,28 @@
+package com.github.aburaagetarou.statistics;
+
+import javax.annotation.Nullable;
+
+/**
+ * 統計対象インターフェース
+ * @author AburaAgeTarou
+ */
+public interface IStatisticsTarget {
+
+	/**
+	 * 統計記録時のカテゴリ名を得る
+	 * @return カテゴリ名
+	 */
+	String getStatCategory();
+
+	/**
+	 * 統計記録時の内容を得る
+	 * @return 名称
+	 */
+	String getStatData();
+
+	/**
+	 * 統計記録時の数量を得る
+	 * @return 数量
+	 */
+	double getStatAmount();
+}

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/IStatisticsWriter.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/IStatisticsWriter.java
@@ -1,0 +1,14 @@
+package com.github.aburaagetarou.statistics;
+
+/**
+ * 統計データ書き込みインターフェース
+ * @author AburaAgeTarou
+ */
+public interface IStatisticsWriter {
+
+	/**
+	 * 統計データを書き込む
+	 * @param content 報酬統計データ
+	 */
+	boolean write(String content);
+}

--- a/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/StatisticsUtil.java
+++ b/multiserverreward/src/main/java/com/github/aburaagetarou/statistics/StatisticsUtil.java
@@ -1,0 +1,115 @@
+package com.github.aburaagetarou.statistics;
+
+import com.github.aburaagetarou.MultiServerReward;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+
+/**
+ * 報酬統計関連のユーティリティクラス
+ * @author AburaAgeTarou
+ */
+public class StatisticsUtil {
+
+	// 統計
+	private static final Map<OfflinePlayer, List<IStatisticsTarget>> statistics = new HashMap<>();
+
+	/**
+	 * 要素をCSV形式に変換する
+	 * @param contents 要素
+	 * @return CSV形式の文字列
+	 */
+	public static String toCSV(String... contents) {
+
+		// エスケープ
+		List<String> list = Arrays.asList(contents);
+		for (int i = 0; i < list.size(); i++) {
+			String content = list.get(i);
+			content = content.replace("\"", "\"\"");
+			content = "\"" + content + "\"";
+			list.set(i, content);
+		}
+		return String.join(",", list);
+	}
+
+	/**
+	 * データを書き込む
+	 * @param writer 統計データ書き込みインターフェース
+	 * @param reward 報酬
+	 * @param player プレイヤー
+	 */
+	public static void writeData(IStatisticsWriter writer, IStatisticsTarget reward, OfflinePlayer player) {
+		Bukkit.getScheduler().runTaskLaterAsynchronously(MultiServerReward.getInstance(), () -> {
+			writer.write(toCSV(player.getName(), reward.getStatCategory(), reward.getStatData(), BigDecimal.valueOf(reward.getStatAmount()).setScale(2, RoundingMode.CEILING).toPlainString()));
+		}, 1L);
+
+		// 統計データの更新
+		List<IStatisticsTarget> rewardList = statistics.getOrDefault(player, new ArrayList<>());
+		rewardList.add(reward);
+		statistics.put(player, rewardList);
+	}
+
+	/**
+	 * 統計データの書き込み
+	 * @param writer 統計データ書き込みインターフェース
+	 */
+	public static void writeStatistics(IStatisticsWriter writer) {
+		for(OfflinePlayer player : statistics.keySet()) {
+			List<IStatisticsTarget> statData = statistics.get(player);
+			statData.sort(Comparator.comparing(IStatisticsTarget::getStatCategory).thenComparing(IStatisticsTarget::getStatData));
+			double amount = 0.0d;
+			String compBefore = "";
+			String categoryBefore = "";
+			String dataBefore = "";
+			for(IStatisticsTarget data : statData) {
+				String comp = data.getStatCategory() + data.getStatData();
+				if(compBefore.isEmpty()) compBefore = comp;
+				if(categoryBefore.isEmpty()) categoryBefore = data.getStatCategory();
+				if(dataBefore.isEmpty()) dataBefore = data.getStatData();
+				if(!compBefore.isEmpty() && !compBefore.equals(comp)) {
+					writer.write(toCSV(player.getName(), categoryBefore, dataBefore, BigDecimal.valueOf(amount).setScale(2, RoundingMode.CEILING).toPlainString()));
+					amount = 0.0d;
+					categoryBefore = data.getStatCategory();
+					dataBefore = data.getStatData();
+				}
+				amount += data.getStatAmount();
+				compBefore = comp;
+			}
+			if(compBefore.isEmpty()) {
+				writer.write(toCSV(player.getName(), categoryBefore, dataBefore, BigDecimal.valueOf(amount).setScale(2, RoundingMode.CEILING).toPlainString()));
+			}
+		}
+
+		// 合計
+		List<IStatisticsTarget> allStatData = new ArrayList<>();
+		for(List<IStatisticsTarget> rewards : statistics.values()) {
+			allStatData.addAll(rewards);
+		}
+		allStatData.sort(Comparator.comparing(IStatisticsTarget::getStatCategory).thenComparing(IStatisticsTarget::getStatData));
+
+		double amount = 0.0d;
+		String compBefore = "";
+		String categoryBefore = "";
+		String dataBefore = "";
+		for(IStatisticsTarget data : allStatData) {
+			String comp = data.getStatCategory() + data.getStatData();
+			if(compBefore.isEmpty()) compBefore = comp;
+			if(categoryBefore.isEmpty()) categoryBefore = data.getStatCategory();
+			if(dataBefore.isEmpty()) dataBefore = data.getStatData();
+			if(!compBefore.isEmpty() && !compBefore.equals(comp)) {
+				writer.write(toCSV("TOTAL", categoryBefore, dataBefore, BigDecimal.valueOf(amount).setScale(2, RoundingMode.CEILING).toPlainString()));
+				amount = 0.0d;
+				categoryBefore = data.getStatCategory();
+				dataBefore = data.getStatData();
+				compBefore = comp;
+			}
+			amount += data.getStatAmount();
+		}
+		if(compBefore.isEmpty()) {
+			writer.write(toCSV("TOTAL", categoryBefore, dataBefore, BigDecimal.valueOf(amount).setScale(2, RoundingMode.CEILING).toPlainString()));
+		}
+	}
+}


### PR DESCRIPTION
ログを `共通ディレクトリ/logs` に `yyyy\_MM\_dd.csv` というファイル名で保存
プラグイン無効化時、統計を `共通ディレクトリ/logs` に `yyyy_MM_dd_stat.csv` というファイル名で保存